### PR TITLE
set z-index of buttons to 0

### DIFF
--- a/src/content/button.ts
+++ b/src/content/button.ts
@@ -73,7 +73,7 @@ function createCustomBtn(svg: string, iconColor: IconColor, className: IconClass
    const newBtn = document.createElement('a');
    newBtn.innerHTML = svg;
    newBtn.className = CLASS_CUSTOM_BUTTON + ' ' + className;
-   newBtn.setAttribute('style', `cursor: pointer;padding:8px;z-index: 999;color:${iconColor}`);
+   newBtn.setAttribute('style', `cursor: pointer;padding:8px;z-index: 0;color:${iconColor}`);
    newBtn.onmouseenter = () => {
       newBtn.style.setProperty('filter', 'drop-shadow(0px 0px 10px deepskyblue)');
    };


### PR DESCRIPTION
On mobile devices with narrow layout, the injected buttons (open in new tab and download) block the bottom navigation bar when page is being scrolled.
The rest of the buttons (e.g. like and share) have z-index of 0. Aligning the z-index fixes the issue.