### PR TITLE
Do not use media index with Instagram story

### DIFF
--- a/src/content/stories.ts
+++ b/src/content/stories.ts
@@ -67,7 +67,7 @@ export async function storyOnClicked(target: HTMLAnchorElement) {
             url: url,
             username: item.user.username,
             datetime: dayjs.unix(media.taken_at),
-            fileId: `${item.id}_${mediaIndex + 1}`,
+            fileId: getMediaName(url),
          });
       } else {
          openInNewTab(url);


### PR DESCRIPTION
The IG Story media index changes dynamically due to story will expire (remove) after 24 hours. Therefore, the index will be lost and two IG stories could result in an identical filename (when the 1st story expires).