### PR TITLE
Remove Indexing from Filename to Avoid Duplication

### DIFF
--- a/src/content/highlights.ts
+++ b/src/content/highlights.ts
@@ -63,13 +63,13 @@ export async function highlightsOnClicked(target: HTMLAnchorElement) {
 
    let mediaIndex = 0;
 
-   const handleMeidas = (data: Highlight.Node) => {
+   const handleMedias = (data: Highlight.Node) => {
       const media = data.items[mediaIndex];
       const url = media.video_versions?.[0].url || media.image_versions2.candidates[0].url;
       final(url, {
          username: data.user.username,
          datetime: dayjs.unix(media.taken_at),
-         fileId: `${data.id}_${mediaIndex + 1}`,
+         fileId: getMediaName(url),
       });
    };
 
@@ -91,7 +91,7 @@ export async function highlightsOnClicked(target: HTMLAnchorElement) {
       const { reels_media } = await chrome.storage.local.get(['reels_media']);
       const itemOnAndroid = (reels_media || []).find((i: ReelsMedia.ReelsMedum) => i.id === 'highlight:' + pathnameArr[3]);
       if (itemOnAndroid) {
-         handleMeidas(itemOnAndroid);
+         handleMedias(itemOnAndroid);
          return;
       }
       for (const item of sectionNode.querySelectorAll<HTMLImageElement>('img')) {
@@ -105,7 +105,7 @@ export async function highlightsOnClicked(target: HTMLAnchorElement) {
    const { highlights_data } = await chrome.storage.local.get(['highlights_data']);
    const localData = new Map(highlights_data).get('highlight:' + pathnameArr[3]) as Highlight.Node | undefined;
    if (localData) {
-      handleMeidas(localData);
+      handleMedias(localData);
       return;
    }
 
@@ -116,7 +116,7 @@ export async function highlightsOnClicked(target: HTMLAnchorElement) {
          if (innerHTML.includes('xdt_api__v1__feed__reels_media__connection')) {
             const res = findHighlight(data);
             if (res) {
-               handleMeidas(res.edges[0].node);
+               handleMedias(res.edges[0].node);
                return;
             }
          }

--- a/src/content/post-detail.ts
+++ b/src/content/post-detail.ts
@@ -136,7 +136,7 @@ export async function postDetailOnClicked(target: HTMLAnchorElement) {
             url: url,
             username: posterName,
             datetime: dayjs(postTime),
-            fileId: fileId || getMediaName(url),
+            fileId: getMediaName(url),
          });
       } else {
          openInNewTab(url);

--- a/src/content/post.ts
+++ b/src/content/post.ts
@@ -153,7 +153,7 @@ export async function postOnClicked(target: HTMLAnchorElement) {
             url: url,
             username: posterName,
             datetime: dayjs(postTime),
-            fileId: fileId || getMediaName(url),
+            fileId: getMediaName(url),
          });
       } else {
          openInNewTab(url);

--- a/src/content/stories.ts
+++ b/src/content/stories.ts
@@ -67,7 +67,7 @@ export async function storyOnClicked(target: HTMLAnchorElement) {
             url: url,
             username: item.user.username,
             datetime: dayjs.unix(media.taken_at),
-            fileId: `${item.id}_${mediaIndex + 1}`,
+            fileId: getMediaName(url),
          });
       } else {
          openInNewTab(url);


### PR DESCRIPTION
The IG Story index changes when a story expires after 24 hours. When the first story expires, the second story becomes the first, the third becomes the second, and so on. Therefore, if a user downloads the same story at a later time, it could result in the same file name being assigned.

The user can reorder the media (photos or videos) within the same post. As a result, the index of the media could change. This means that if a user re-downloads the reordered media, two scenarios may occur:

The same media could be saved under a different file name due to the index change, or
Two media items could have the same file name because of the re-ordered indexing.