### PR TITLE
feat: add option to disable video controls on IG explore page

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,7 @@ export const CONFIG_LIST = [
     'setting_show_zip_download_icon',
     'setting_enable_threads',
     'setting_enable_video_controls',
+    'setting_enable_explore_video_clickthrough',
     'setting_format_replace_jpeg_with_jpg',
     'setting_format_use_hash_id',
     'setting_format_use_indexing',

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -9,6 +9,7 @@ function App() {
    const [newTab, setNewTab] = useState<boolean>(true);
    const [threads, setThreads] = useState<boolean>(true);
    const [enableVideoControl, setEnableVideoControl] = useState<boolean>(true);
+   const [enableExploreClickthrough, setEnableExploreClickthrough] = useState<boolean>(true);
    const [replaceJpegWithJpg, setReplaceJpegWithJpg] = useState<boolean>(true);
    const [useHashId, setUseHashId] = useState<boolean>(false);
    const [useIndexing, setUseIndexing] = useState<boolean>(true);
@@ -25,6 +26,7 @@ function App() {
          setNewTab(!!res.setting_show_open_in_new_tab_icon);
          setThreads(!!res.setting_enable_threads);
          setEnableVideoControl(!!res.setting_enable_video_controls);
+         setEnableExploreClickthrough(res.setting_enable_explore_video_clickthrough ?? true);
          setReplaceJpegWithJpg(!!res.setting_format_replace_jpeg_with_jpg);
          setUseHashId(!!res.setting_format_use_hash_id);
          setUseIndexing(!!res.setting_format_use_indexing);
@@ -163,6 +165,12 @@ function App() {
                   setValue={setEnableVideoControl}
                   label="Show Controls Offered By Browser"
                   id="setting_enable_video_controls"
+               />
+               <SettingItem
+                  value={enableExploreClickthrough}
+                  setValue={setEnableExploreClickthrough}
+                  label="Clicking explore videos opens the post"
+                  id="setting_enable_explore_video_clickthrough"
                />
 
                <h2>Threads Settings</h2>


### PR DESCRIPTION
An option has been added to disable video controls on the Explore page in response to issue #87. 