### PR TITLE
fix: ZIP button not working issue

### DIFF
--- a/src/content/utils/fn.ts
+++ b/src/content/utils/fn.ts
@@ -130,7 +130,7 @@ function findPostId(articleNode: HTMLElement) {
     } else if (pathname.startsWith('/reel/')) {
         return pathname.split('/')[2];
     }
-    const postIdPattern = /^\/p\/([^/]+)\//;
+    const postIdPattern = /\/p\/([^/]+)\//;
     const aNodes = articleNode.querySelectorAll('a');
     for (let i = 0; i < aNodes.length; ++i) {
         const link = aNodes[i].getAttribute('href');


### PR DESCRIPTION
Allow /profile/p/:id path by removing start anchor in regex.

The original regex only matched paths starting with /p/, 
causing URLs like /profile/p/:id/ to fail.
For example, href looks like "/profile/p/ID" returns null.

This change removes the start anchor so it correctly matches post IDs in nested paths.

Tested URLs:
- /p/abc123/
- /username/p/abc123/

fix (suspected) #96 