### PR TITLE
Fetch HD profile avatars from mobile API

### DIFF
--- a/src/background/chrome.ts
+++ b/src/background/chrome.ts
@@ -1,6 +1,19 @@
 import type { ReelsMedia } from '../types/global';
-import { findValueByKey, saveHighlights, saveProfileReel, saveReels, saveStories } from './fn';
-import { CONFIG_LIST, MESSAGE_OPEN_URL, DEFAULT_FILENAME_FORMAT, DEFAULT_DATETIME_FORMAT } from '../constants';
+import {
+    fetchInstagramProfilePictureHdUrl,
+    findValueByKey,
+    saveHighlights,
+    saveProfileReel,
+    saveReels,
+    saveStories
+} from './fn';
+import {
+    CONFIG_LIST,
+    DEFAULT_DATETIME_FORMAT,
+    DEFAULT_FILENAME_FORMAT,
+    MESSAGE_FETCH_PROFILE_PICTURE_HD,
+    MESSAGE_OPEN_URL
+} from '../constants';
 
 chrome.runtime.onInstalled.addListener(async () => {
     const result = await chrome.storage.sync.get(CONFIG_LIST);
@@ -25,11 +38,51 @@ chrome.runtime.onStartup.addListener(() => {
     chrome.storage.local.set({ stories_user_ids: [], id_to_username_map: [] });
 });
 
-chrome.runtime.onMessage.addListener((message, sender) => {
+function getInstagramCookie(name: string) {
+    return new Promise<string | null>((resolve) => {
+        chrome.cookies.get({ url: 'https://www.instagram.com/', name }, (cookie) => {
+            const lastError = (chrome.runtime as any).lastError;
+
+            if (lastError) {
+                console.log(`Could not read Instagram cookie ${name}: ${lastError.message}`);
+                resolve(null);
+                return;
+            }
+
+            resolve(cookie?.value || null);
+        });
+    });
+}
+
+function getProfilePictureUserId(data: unknown) {
+    if (typeof data === 'string') return data;
+    if (data && typeof data === 'object' && typeof (data as Record<string, unknown>).userId === 'string') {
+        return (data as Record<string, string>).userId;
+    }
+    return null;
+}
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     console.log(message, sender);
     const { type, data } = message;
     if (type === MESSAGE_OPEN_URL) {
         chrome.tabs.create({ url: data, index: sender.tab!.index + 1 });
+    }
+    if (type === MESSAGE_FETCH_PROFILE_PICTURE_HD) {
+        const userId = getProfilePictureUserId(data);
+        if (!userId) {
+            sendResponse({ url: null });
+            return false;
+        }
+
+        fetchInstagramProfilePictureHdUrl(userId, getInstagramCookie)
+            .then((url) => sendResponse({ url }))
+            .catch((error) => {
+                console.log(`Could not fetch HD profile picture: ${error}`);
+                sendResponse({ url: null });
+            });
+
+        return true;
     }
     return false;
 });

--- a/src/background/firefox.ts
+++ b/src/background/firefox.ts
@@ -2,11 +2,19 @@ import {
     CONFIG_LIST,
     DEFAULT_DATETIME_FORMAT,
     DEFAULT_FILENAME_FORMAT,
+    MESSAGE_FETCH_PROFILE_PICTURE_HD,
     MESSAGE_OPEN_URL,
     MESSAGE_ZIP_DOWNLOAD
 } from '../constants';
 import type { ReelsMedia } from '../types/global';
-import { findValueByKey, saveHighlights, saveProfileReel, saveReels, saveStories } from './fn';
+import {
+    fetchInstagramProfilePictureHdUrl,
+    findValueByKey,
+    saveHighlights,
+    saveProfileReel,
+    saveReels,
+    saveStories
+} from './fn';
 
 browser.runtime.onInstalled.addListener(async () => {
     // 1. Initialize default settings
@@ -218,6 +226,19 @@ browser.webRequest.onBeforeRequest.addListener(
     ['blocking']
 );
 
+async function getInstagramCookie(name: string) {
+    const cookie = await browser.cookies.get({ url: 'https://www.instagram.com/', name });
+    return cookie?.value || null;
+}
+
+function getProfilePictureUserId(data: unknown) {
+    if (typeof data === 'string') return data;
+    if (data && typeof data === 'object' && typeof (data as Record<string, unknown>).userId === 'string') {
+        return (data as Record<string, string>).userId;
+    }
+    return null;
+}
+
 browser.runtime.onMessage.addListener(async (message, sender) => {
     console.log(message, sender);
     const { type, data } = message;
@@ -225,6 +246,17 @@ browser.runtime.onMessage.addListener(async (message, sender) => {
         case MESSAGE_OPEN_URL:
             await browser.tabs.create({ url: data, index: sender.tab!.index + 1 });
             break;
+        case MESSAGE_FETCH_PROFILE_PICTURE_HD:
+            const userId = getProfilePictureUserId(data);
+            if (!userId) {
+                return { url: null };
+            }
+            try {
+                return { url: await fetchInstagramProfilePictureHdUrl(userId, getInstagramCookie) };
+            } catch (error) {
+                console.log(`Could not fetch HD profile picture: ${error}`);
+                return { url: null };
+            }
         case MESSAGE_ZIP_DOWNLOAD:
             const { BlobReader, BlobWriter, TextReader, ZipWriter } = await import('@zip.js/zip.js');
             const zipFileWriter = new BlobWriter();

--- a/src/background/fn.ts
+++ b/src/background/fn.ts
@@ -69,3 +69,91 @@ export function findValueByKey(obj: Record<string, any>, key: string): any {
         }
     }
 }
+
+type InstagramCookieReader = (name: string) => Promise<string | null | undefined>;
+
+interface ProfilePictureVersion {
+    height?: number;
+    url?: string;
+    width?: number;
+}
+
+function getRecord(value: unknown): Record<string, any> | null {
+    return value && typeof value === 'object' ? value as Record<string, any> : null;
+}
+
+function getLargestProfilePictureVersionUrl(versions: unknown): string | null {
+    if (!Array.isArray(versions)) return null;
+
+    const largestVersion = versions
+        .filter((version): version is ProfilePictureVersion => typeof version?.url === 'string')
+        .sort((left, right) => {
+            const leftSize = (left.width || 0) * (left.height || 0);
+            const rightSize = (right.width || 0) * (right.height || 0);
+            return rightSize - leftSize;
+        })[0];
+
+    return largestVersion?.url || null;
+}
+
+function getProfilePictureUrlFromInfoResponse(data: unknown): string | null {
+    const root = getRecord(data);
+    const user = getRecord(root?.user);
+    if (!user) return null;
+
+    const hdInfo = getRecord(user.hd_profile_pic_url_info);
+    return (
+        (typeof hdInfo?.url === 'string' && hdInfo.url) ||
+        getLargestProfilePictureVersionUrl(user.hd_profile_pic_versions) ||
+        (typeof user.profile_pic_url_hd === 'string' && user.profile_pic_url_hd) ||
+        (typeof user.profile_pic_url === 'string' && user.profile_pic_url) ||
+        null
+    );
+}
+
+function getProfilePictureRequestHeaders(authHeader: string, includeUserAgent: boolean) {
+    const headers: Record<string, string> = {
+        Accept: 'application/json',
+        Authorization: authHeader,
+        'X-IG-App-ID': '350685531728',
+    };
+
+    if (includeUserAgent) {
+        headers['User-Agent'] = 'Instagram 219.0.0.12.117 Android';
+    }
+
+    return headers;
+}
+
+async function fetchProfilePictureInfo(userId: string, authHeader: string) {
+    const url = `https://i.instagram.com/api/v1/users/${encodeURIComponent(userId)}/info/`;
+
+    try {
+        return await fetch(url, {
+            headers: getProfilePictureRequestHeaders(authHeader, true),
+        });
+    } catch (error) {
+        console.log(`Retrying profile picture request without User-Agent header: ${error}`);
+        return fetch(url, {
+            headers: getProfilePictureRequestHeaders(authHeader, false),
+        });
+    }
+}
+
+export async function fetchInstagramProfilePictureHdUrl(userId: string, getCookie: InstagramCookieReader) {
+    const [sessionId, dsUserId] = await Promise.all([
+        getCookie('sessionid'),
+        getCookie('ds_user_id'),
+    ]);
+
+    if (!sessionId || !dsUserId) return null;
+
+    const authPayload = JSON.stringify({ ds_user_id: dsUserId, sessionid: sessionId });
+    const response = await fetchProfilePictureInfo(userId, `Bearer IGT:2:${btoa(authPayload)}`);
+
+    if (!response.ok) {
+        throw new Error(`Instagram profile picture request failed with status ${response.status}`);
+    }
+
+    return getProfilePictureUrlFromInfoResponse(await response.json());
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -29,3 +29,4 @@ export const CLASS_CUSTOM_BUTTON = 'custom-btn';
 
 export const MESSAGE_OPEN_URL = "open_url"
 export const MESSAGE_ZIP_DOWNLOAD = "zip_download"
+export const MESSAGE_FETCH_PROFILE_PICTURE_HD = "fetch_profile_picture_hd"

--- a/src/content/profile.ts
+++ b/src/content/profile.ts
@@ -1,19 +1,311 @@
+import { MESSAGE_FETCH_PROFILE_PICTURE_HD } from '../constants';
 import { downloadResource, openInNewTab } from './utils/fn';
 
-export async function profileOnClicked(target: HTMLAnchorElement) {
-    const { user_profile_pic_url } = await chrome.storage.local.get(['user_profile_pic_url']);
-    const data = new Map(user_profile_pic_url || []);
-    const arr = window.location.pathname.split('/').filter((e) => e);
-    const username = arr.length === 1 ? arr[0] : document.querySelector('main header h2')?.textContent;
-    const url = data.get(username) || document.querySelector('header img')?.getAttribute('src');
-    if (typeof url === 'string') {
-        if (target.className.includes('download-btn')) {
-            downloadResource({
-                url: url,
-                id: username!,
-            });
-        } else {
-            openInNewTab(url);
+const PROFILE_AVATAR_CACHE_KEY = 'user_profile_pic_url';
+const PROFILE_AVATAR_HD_CACHE_KEY = 'user_profile_hd_pic_url_v2';
+const WEB_PROFILE_APP_ID = '936619743392459';
+
+type AvatarQuality = 'fallback' | 'high';
+
+interface AvatarCandidate {
+    quality: AvatarQuality;
+    url?: string;
+}
+
+interface AvatarVersion {
+    height?: number;
+    url?: string;
+    width?: number;
+}
+
+interface ProfileAvatarUser {
+    hd_profile_pic_url_info?: {
+        url?: string;
+    };
+    hd_profile_pic_versions?: AvatarVersion[];
+    id?: number | string;
+    pk?: number | string;
+    pk_id?: number | string;
+    profile_pic_url?: string;
+    profile_pic_url_hd?: string;
+    username?: string;
+}
+
+interface ProfilePictureResponse {
+    url?: string | null;
+}
+
+function normalizeUsername(username: string) {
+    return username.trim().toLowerCase();
+}
+
+function getStringMap(value: unknown) {
+    return new Map<string, string>(
+        Array.isArray(value)
+            ? value.filter((entry): entry is [string, string] => (
+                Array.isArray(entry) &&
+                typeof entry[0] === 'string' &&
+                typeof entry[1] === 'string'
+            ))
+            : []
+    );
+}
+
+function getProfileUsername() {
+    const reservedPathSegments = new Set([
+        'accounts',
+        'direct',
+        'explore',
+        'p',
+        'reel',
+        'reels',
+        'stories',
+    ]);
+    const pathnameParts = window.location.pathname.split('/').filter(Boolean);
+    const usernameFromPath = pathnameParts[0];
+
+    if (usernameFromPath && !reservedPathSegments.has(usernameFromPath)) {
+        return usernameFromPath;
+    }
+
+    return document.querySelector('main header h2')?.textContent?.trim() || null;
+}
+
+function getProfileAvatarImage(root: ParentNode = document) {
+    const username = getProfileUsername();
+    const normalizedUsername = username ? normalizeUsername(username) : null;
+    const header = document.querySelector('section>main>div>header') || document.querySelector('header') || root;
+    const images = [...header.querySelectorAll<HTMLImageElement>('img')];
+
+    return images.find((img) => {
+        const alt = img.alt.toLowerCase();
+        return (
+            alt.includes('profile') ||
+            alt.includes('profil') ||
+            Boolean(normalizedUsername && alt.includes(normalizedUsername))
+        );
+    }) || images[0] || null;
+}
+
+function getProfileAvatarUrl(root: ParentNode = document) {
+    return getProfileAvatarImage(root)?.getAttribute('src') || undefined;
+}
+
+function getRecord(value: unknown): Record<string, any> | null {
+    return value && typeof value === 'object' ? value as Record<string, any> : null;
+}
+
+function findProfileAvatarUser(value: unknown): ProfileAvatarUser | null {
+    const record = getRecord(value);
+    if (!record) return null;
+
+    if (
+        typeof record.username === 'string' &&
+        (
+            typeof record.profile_pic_url === 'string' ||
+            typeof record.profile_pic_url_hd === 'string' ||
+            getRecord(record.hd_profile_pic_url_info) ||
+            Array.isArray(record.hd_profile_pic_versions)
+        )
+    ) {
+        return record as ProfileAvatarUser;
+    }
+
+    for (const nestedValue of Object.values(record)) {
+        const result = findProfileAvatarUser(nestedValue);
+        if (result) return result;
+    }
+
+    return null;
+}
+
+function normalizeAvatarCandidateUrl(url: unknown) {
+    return typeof url === 'string' && url.trim()
+        ? url.replace(/&amp;/g, '&')
+        : undefined;
+}
+
+function getLargestAvatarVersionUrl(versions: unknown) {
+    if (!Array.isArray(versions)) return undefined;
+
+    return versions
+        .filter((version): version is AvatarVersion => typeof version?.url === 'string')
+        .sort((left, right) => {
+            const leftSize = (left.width || 0) * (left.height || 0);
+            const rightSize = (right.width || 0) * (right.height || 0);
+            return rightSize - leftSize;
+        })[0]?.url;
+}
+
+function isLikelyLowResolutionAvatarUrl(url: string) {
+    const sizeMatches = url.matchAll(/(?:^|[_/-])s(\d+)x(\d+)(?=[_./-]|$)/gi);
+
+    for (const match of sizeMatches) {
+        const width = Number(match[1]);
+        const height = Number(match[2]);
+
+        if (Number.isFinite(width) && Number.isFinite(height) && Math.max(width, height) <= 320) {
+            return true;
         }
+    }
+
+    return /(?:^|[_/-])p150x150(?=[_./-]|$)/i.test(url);
+}
+
+function getProfileAvatarCandidatesFromApiData(data: unknown): AvatarCandidate[] {
+    const user = findProfileAvatarUser(data);
+    if (!user) return [];
+
+    return [
+        { quality: 'high', url: user.hd_profile_pic_url_info?.url },
+        { quality: 'high', url: user.profile_pic_url_hd },
+        { quality: 'high', url: getLargestAvatarVersionUrl(user.hd_profile_pic_versions) },
+        { quality: 'fallback', url: user.profile_pic_url },
+    ];
+}
+
+function getHighResolutionProfileAvatarUrlFromApiData(data: unknown) {
+    return getProfileAvatarCandidatesFromApiData(data)
+        .filter((candidate) => candidate.quality === 'high')
+        .map((candidate) => normalizeAvatarCandidateUrl(candidate.url))
+        .find((url): url is string => Boolean(url && !isLikelyLowResolutionAvatarUrl(url)));
+}
+
+function getProfileAvatarUrlFromApiData(data: unknown) {
+    const highResolutionUrl = getHighResolutionProfileAvatarUrlFromApiData(data);
+    if (highResolutionUrl) return highResolutionUrl;
+
+    return getProfileAvatarCandidatesFromApiData(data)
+        .map((candidate) => normalizeAvatarCandidateUrl(candidate.url))
+        .find((url): url is string => Boolean(url));
+}
+
+function getProfileUserIdFromApiData(data: unknown) {
+    const user = findProfileAvatarUser(data);
+    const userId = user?.id || user?.pk || user?.pk_id;
+    return typeof userId === 'string' || typeof userId === 'number' ? String(userId) : null;
+}
+
+async function cacheProfileAvatarUrl(username: string, url: string, quality: AvatarQuality = 'high') {
+    const avatarStorage = await chrome.storage.local.get([
+        PROFILE_AVATAR_HD_CACHE_KEY,
+        PROFILE_AVATAR_CACHE_KEY,
+    ]);
+    const cacheKey = normalizeUsername(username);
+    const data = getStringMap(avatarStorage[PROFILE_AVATAR_CACHE_KEY]);
+    const hdData = getStringMap(avatarStorage[PROFILE_AVATAR_HD_CACHE_KEY]);
+
+    data.set(cacheKey, url);
+    if (quality === 'high') {
+        hdData.set(cacheKey, url);
+    }
+
+    await chrome.storage.local.set({
+        [PROFILE_AVATAR_CACHE_KEY]: [...data],
+        [PROFILE_AVATAR_HD_CACHE_KEY]: [...hdData],
+    });
+}
+
+function fetchHighResolutionProfileAvatarUrl(userId: string) {
+    return chrome.runtime
+        .sendMessage({
+            data: { userId },
+            type: MESSAGE_FETCH_PROFILE_PICTURE_HD,
+        })
+        .then((response?: ProfilePictureResponse) => normalizeAvatarCandidateUrl(response?.url))
+        .catch((error) => {
+            console.log(`Could not fetch HD profile picture: ${error}`);
+            return undefined;
+        });
+}
+
+async function fetchProfileAvatarData(endpoint: string) {
+    const response = await fetch(endpoint, {
+        credentials: 'include',
+        headers: {
+            Accept: 'application/json',
+            'X-IG-App-ID': WEB_PROFILE_APP_ID,
+        },
+    });
+
+    if (!response.ok) {
+        throw new Error(`Instagram profile request failed with status ${response.status}`);
+    }
+
+    return response.json();
+}
+
+async function fetchProfileAvatarUrl(username: string) {
+    const encodedUsername = encodeURIComponent(username);
+    const endpoints = [
+        `https://www.instagram.com/api/v1/users/web_profile_info/?username=${encodedUsername}`,
+        `https://www.instagram.com/api/v1/feed/user/${encodedUsername}/username/`,
+    ];
+
+    for (const endpoint of endpoints) {
+        try {
+            const data = await fetchProfileAvatarData(endpoint);
+            const userId = getProfileUserIdFromApiData(data);
+            const highResolutionUrl = getHighResolutionProfileAvatarUrlFromApiData(data);
+            const fallbackUrl = getProfileAvatarUrlFromApiData(data);
+
+            if (userId) {
+                const mobileApiUrl = await fetchHighResolutionProfileAvatarUrl(userId);
+
+                if (mobileApiUrl) {
+                    await cacheProfileAvatarUrl(username, mobileApiUrl);
+                    return mobileApiUrl;
+                }
+            }
+
+            if (highResolutionUrl) {
+                await cacheProfileAvatarUrl(username, highResolutionUrl);
+                return highResolutionUrl;
+            }
+
+            if (fallbackUrl) {
+                await cacheProfileAvatarUrl(username, fallbackUrl, 'fallback');
+                return fallbackUrl;
+            }
+        } catch (error) {
+            console.log(`Failed to fetch profile avatar from ${endpoint}: ${error}`);
+        }
+    }
+
+    return undefined;
+}
+
+async function resolveProfileAvatarUrl(username: string | null) {
+    const avatarStorage = await chrome.storage.local.get([
+        PROFILE_AVATAR_HD_CACHE_KEY,
+        PROFILE_AVATAR_CACHE_KEY,
+    ]);
+    const cacheKey = username ? normalizeUsername(username) : null;
+    const hdData = getStringMap(avatarStorage[PROFILE_AVATAR_HD_CACHE_KEY]);
+    const data = getStringMap(avatarStorage[PROFILE_AVATAR_CACHE_KEY]);
+    const cachedHdUrl = cacheKey ? hdData.get(cacheKey) || hdData.get(username || '') : undefined;
+    const cachedUrl = cacheKey ? data.get(cacheKey) || data.get(username || '') : undefined;
+
+    if (cachedHdUrl && !isLikelyLowResolutionAvatarUrl(cachedHdUrl)) {
+        return cachedHdUrl;
+    }
+
+    const apiUrl = username ? await fetchProfileAvatarUrl(username) : undefined;
+    return apiUrl || cachedUrl || getProfileAvatarUrl();
+}
+
+export async function profileOnClicked(target: HTMLAnchorElement) {
+    const username = getProfileUsername();
+    const url = await resolveProfileAvatarUrl(username);
+
+    if (!url) return;
+
+    if (target.className.includes('download-btn')) {
+        downloadResource({
+            id: username || 'profile-picture',
+            url,
+        });
+    } else {
+        openInNewTab(url);
     }
 }

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -21,8 +21,13 @@
     "default_popup": "popup/index.html"
   },
   "permissions": [
+    "cookies",
     "storage",
     "unlimitedStorage"
+  ],
+  "host_permissions": [
+    "https://*.instagram.com/*",
+    "https://www.threads.com/*"
   ],
   "background": {
     "service_worker": "background/chrome.js",

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -24,10 +24,11 @@
     "default_popup": "popup/index.html"
   },
   "host_permissions": [
-    "https://www.instagram.com/*",
+    "https://*.instagram.com/*",
     "https://www.threads.com/*"
   ],
   "permissions": [
+    "cookies",
     "storage",
     "unlimitedStorage",
     "webRequest",


### PR DESCRIPTION
## Summary
- Resolve profile-picture downloads through Instagram profile metadata before falling back to cached/DOM thumbnails
- Add background support for fetching the mobile user-info HD avatar URL with Instagram auth cookies
- Add Chrome/Firefox permissions needed for the HD profile-picture request

## Verification
- `npx tsc --noEmit`
- `npx eslint src/content/profile.ts src/background/fn.ts src/background/chrome.ts src/background/firefox.ts`
- `npx esbuild src/content/index.ts src/background/chrome.ts src/background/firefox.ts --bundle --format=esm --outdir=C:\Users\PC\AppData\Local\Temp/instagram-extension-bundle-check`